### PR TITLE
IO工具问题

### DIFF
--- a/kalle/src/main/java/com/yanzhenjie/kalle/util/IOUtils.java
+++ b/kalle/src/main/java/com/yanzhenjie/kalle/util/IOUtils.java
@@ -321,7 +321,7 @@ public class IOUtils {
     public static void write(InputStream input, OutputStream output) throws IOException {
         int len;
         byte[] buffer = new byte[4096];
-        while ((len = input.read(buffer)) != -1) {
+        while ((len = input.read(buffer)) > 0) {
             output.write(buffer, 0, len);
             output.flush();
         }
@@ -362,7 +362,7 @@ public class IOUtils {
     public static void write(Reader input, Writer output) throws IOException {
         int len;
         char[] buffer = new char[4096];
-        while (-1 != (len = input.read(buffer))) {
+        while (0< (len = input.read(buffer))) {
             output.write(buffer, 0, len);
             output.flush();
         }
@@ -373,7 +373,7 @@ public class IOUtils {
         input2 = toBufferedInputStream(input2);
 
         int ch = input1.read();
-        while (-1 != ch) {
+        while (0< ch) {
             int ch2 = input2.read();
             if (ch != ch2) return false;
             ch = input1.read();
@@ -388,7 +388,7 @@ public class IOUtils {
         input2 = toBufferedReader(input2);
 
         int ch = input1.read();
-        while (-1 != ch) {
+        while (0< ch) {
             int ch2 = input2.read();
             if (ch != ch2) return false;
             ch = input1.read();


### PR DESCRIPTION
Actual test found,!=-1 in some cases will cause an infinite loop, which will make the entire frame unable to continue running. Replace it with >. 0 can be solved.

实际测试发现，!=-1在部分情况下会导致死循环，使整个框架无法继续运行，替换成>0可解决。